### PR TITLE
feat(variation): add controller, repository contract, zod validation …

### DIFF
--- a/backend/src/controllers/VariationController.ts
+++ b/backend/src/controllers/VariationController.ts
@@ -1,0 +1,75 @@
+import { Request, Response } from "express";
+import { AuthRequest } from "../types/AuthRequest";
+import { IVariationRepository } from "../repositories/contracts/IVariationRepository";
+import { StatusCodes } from "http-status-codes";
+
+export class VariationController {
+    constructor(private repo: IVariationRepository) { }
+
+    async create(req: AuthRequest, res: Response) {
+        try {
+            const variation = await this.repo.create(req.body);
+
+            if (!variation) {
+                return res.status(StatusCodes.BAD_REQUEST).json({ error: "Failed to create variation" });
+            }
+
+            return res.status(StatusCodes.OK).json(variation);
+        } catch (err) {
+            return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ error: "Failed to create variation" });
+        }
+    }
+
+    async show(req: Request, res: Response) {
+        try {
+            const id = parseInt(req.params.id);
+            if (isNaN(id)) {
+                return res.status(StatusCodes.BAD_REQUEST).json({ error: "ID inválido" });
+            }
+
+            const variation = await this.repo.findById(id);
+
+            if (!variation) {
+                return res.status(StatusCodes.NOT_FOUND).json({ error: "Variation not found" });
+            }
+
+            return res.status(StatusCodes.OK).json(variation);
+        } catch (err) {
+            return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ error: "Failed to fetch variation" });
+        }
+    }
+
+    async update(req: Request, res: Response) {
+        try {
+            const id = parseInt(req.params.id);
+            if (isNaN(id)) {
+                return res.status(StatusCodes.BAD_REQUEST).json({ error: "ID inválido" });
+            }
+
+            const variation = await this.repo.update(id, req.body);
+
+            return res.status(StatusCodes.OK).json(variation);
+        } catch (err) {
+            return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ error: "Failed to update variation" });
+        }
+    }
+
+    async destroy(req: Request, res: Response) {
+        try {
+            const id = parseInt(req.params.id);
+            if (isNaN(id)) {
+                return res.status(StatusCodes.BAD_REQUEST).json({ error: "ID inválido" });
+            }
+
+            const variation = await this.repo.delete(id);
+
+            if (!variation) {
+                return res.status(StatusCodes.NOT_FOUND).json({ error: "Variation not found" });
+            }
+
+            return res.status(StatusCodes.NO_CONTENT).send();
+        } catch (err) {
+            return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ error: "Failed to delete variation" });
+        }
+    }
+};

--- a/backend/src/repositories/contracts/IVariationRepository.ts
+++ b/backend/src/repositories/contracts/IVariationRepository.ts
@@ -1,0 +1,10 @@
+import { Prisma, Variation } from '@prisma/client';
+import { IBaseRepository } from '../IBaseRepository';
+
+export interface IVariationRepository extends IBaseRepository<Variation> {
+    create(data: Prisma.VariationCreateInput): Promise<Variation>
+    count(): Promise<number>;
+    findById(id: number): Promise<Variation | null>;
+    update(id: number, data: Prisma.VariationUpdateInput): Promise<Variation>;
+    delete(id: number): Promise<Variation>;
+}

--- a/backend/src/repositories/prisma/PrismaVariationRepository.ts
+++ b/backend/src/repositories/prisma/PrismaVariationRepository.ts
@@ -1,0 +1,35 @@
+import { Prisma, Variation } from "@prisma/client";
+import { BaseRepository } from "../BaseRepository";
+import { prisma } from "../../lib/prismaClient";
+import { IVariationRepository } from "../contracts/IVariationRepository";
+
+export class PrismaVariationRepository extends BaseRepository<Variation> implements IVariationRepository {
+    constructor() {
+        super(prisma.user)
+    }
+
+    async create(data: Prisma.VariationCreateInput): Promise<Variation> {
+        return prisma.variation.create({ data })
+    }
+
+    async count(): Promise<number> {
+        return prisma.user.count();
+    }
+
+    async findById(id: number): Promise<Variation | null> {
+        return prisma.variation.findUnique({ where: { id } });
+    }
+
+    async update(id: number, data: Prisma.VariationUpdateInput): Promise<Variation> {
+        return prisma.variation.update({
+            where: { id },
+            data,
+        });
+    }
+
+    async delete(id: number): Promise<Variation> {
+        return prisma.variation.delete({
+            where: { id },
+        });
+    }
+}

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -3,6 +3,7 @@ import serviceTypeRoutes from "./serviceTypeRoutes";
 import userRoutes from "./userRoutes";
 import authRoutes from "./authRoutes";
 import serviceRoutes from "./serviceRoutes";
+import variationRoutes from "./variationRoutes";
 
 const router = Router();
 
@@ -10,5 +11,6 @@ router.use("/auth", authRoutes)
 router.use("/users", userRoutes);
 router.use("/service-types", serviceTypeRoutes);
 router.use("/service", serviceRoutes);
+router.use("/variation", variationRoutes)
 
 export default router;

--- a/backend/src/routes/userRoutes.ts
+++ b/backend/src/routes/userRoutes.ts
@@ -12,9 +12,9 @@ const userController = new UserController(userRepo);
 
 userRoutes.use(authMiddleware, adminMiddleware);
 
-userRoutes.get("/users", userController.index.bind(userController));
-userRoutes.get("/users/:id", userController.show.bind(userController));
-userRoutes.put("/users/:id", validateData(UserUpdateInput), userController.update.bind(userController));
-userRoutes.delete("/users/:id", userController.destroy.bind(userController));
+userRoutes.get("/", userController.index.bind(userController));
+userRoutes.get("/show/:id", userController.show.bind(userController));
+userRoutes.put("/update/:id", validateData(UserUpdateInput), userController.update.bind(userController));
+userRoutes.delete("/destroy/:id", userController.destroy.bind(userController));
 
 export default userRoutes;

--- a/backend/src/routes/variationRoutes.ts
+++ b/backend/src/routes/variationRoutes.ts
@@ -1,0 +1,14 @@
+import { Router } from "express";
+import { VariationController } from "../controllers/VariationController";
+import { PrismaVariationRepository } from "../repositories/prisma/PrismaVariationRepository";
+
+const variationRoutes = Router();
+const variationRepo = new PrismaVariationRepository();
+const variationController = new VariationController(variationRepo)
+
+variationRoutes.post("/store", variationController.create.bind(variationController));
+variationRoutes.get("/show/:id", variationController.show.bind(variationController));
+variationRoutes.put("/update/:id", variationController.update.bind(variationController));
+variationRoutes.delete("/destroy/:id", variationController.destroy.bind(variationController));
+
+export default variationRoutes;

--- a/backend/src/schemas/variationSchemas.ts
+++ b/backend/src/schemas/variationSchemas.ts
@@ -1,0 +1,36 @@
+import z from "zod";
+
+export const createVariationSchema = z.object({
+    name: z
+        .string()
+        .min(2, "Name must be at least 2 characters long")
+        .max(100, "Name must be at most 100 characters long"),
+    price: z
+        .number()
+        .positive("Price must be greater than 0"),
+    duration: z
+        .number()
+        .int("Duration must be an integer")
+        .positive("Duration must be greater than 0"),
+    serviceId: z
+        .number()
+        .int("Service ID must be an integer")
+        .positive("Service ID must be greater than 0"),
+});
+
+export const updateVariationSchema = z.object({
+    name: z
+        .string()
+        .min(2, "Name must be at least 2 characters long")
+        .max(100, "Name must be at most 100 characters long")
+        .optional(),
+    price: z
+        .number()
+        .positive("Price must be greater than 0")
+        .optional(),
+    duration: z
+        .number()
+        .int("Duration must be an integer")
+        .positive("Duration must be greater than 0")
+        .optional(),
+});

--- a/backend/tests/controllers/variationController.test.ts
+++ b/backend/tests/controllers/variationController.test.ts
@@ -1,0 +1,186 @@
+import { Request, Response } from "express";
+import { VariationController } from "../../src/controllers/VariationController";
+import { IVariationRepository } from "../../src/repositories/contracts/IVariationRepository";
+import { StatusCodes } from "http-status-codes";
+
+describe("VariationController", () => {
+    let mockRepo: jest.Mocked<IVariationRepository>;
+    let controller: VariationController;
+    let mockRes: Partial<Response>;
+
+    beforeEach(() => {
+        mockRepo = {
+            create: jest.fn(),
+            count: jest.fn(),
+            findById: jest.fn(),
+            update: jest.fn(),
+            delete: jest.fn(),
+            findAll: jest.fn(),
+            paginateFromReq: jest.fn(),
+            page: jest.fn(),
+            limit: jest.fn(),
+            skip: jest.fn(),
+        };
+
+        controller = new VariationController(mockRepo);
+
+        mockRes = {
+            status: jest.fn().mockReturnThis(),
+            json: jest.fn(),
+            send: jest.fn(),
+        };
+    });
+
+    describe("create", () => {
+        it("should create a variation successfully", async () => {
+            const req = { body: { name: "Basic", price: 50, duration: 30, serviceId: 1 } } as any;
+            const variation = { id: 1, ...req.body };
+            mockRepo.create.mockResolvedValue(variation);
+
+            await controller.create(req, mockRes as Response);
+
+            expect(mockRepo.create).toHaveBeenCalledWith(req.body);
+            expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.OK);
+            expect(mockRes.json).toHaveBeenCalledWith(variation);
+        });
+
+        it("should return 400 if creation fails", async () => {
+            const req = { body: { name: "Basic" } } as any;
+            mockRepo.create.mockResolvedValue(null as any);
+
+            await controller.create(req, mockRes as Response);
+
+            expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST);
+            expect(mockRes.json).toHaveBeenCalledWith({ error: "Failed to create variation" });
+        });
+
+        it("should return 500 if repository throws", async () => {
+            const req = { body: {} } as any;
+            mockRepo.create.mockRejectedValue(new Error("DB error"));
+
+            await controller.create(req, mockRes as Response);
+
+            expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.INTERNAL_SERVER_ERROR);
+            expect(mockRes.json).toHaveBeenCalledWith({ error: "Failed to create variation" });
+        });
+    });
+
+    describe("show", () => {
+        it("should return a variation by ID", async () => {
+            const req = { params: { id: "1" } } as any;
+            const variation = { id: 1, name: "Basic", price: 50, duration: 30, serviceId: 1 };
+            mockRepo.findById.mockResolvedValue(variation);
+
+            await controller.show(req, mockRes as Response);
+
+            expect(mockRepo.findById).toHaveBeenCalledWith(1);
+            expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.OK);
+            expect(mockRes.json).toHaveBeenCalledWith(variation);
+        });
+
+        it("should return 400 if ID is invalid", async () => {
+            const req = { params: { id: "abc" } } as any;
+
+            await controller.show(req, mockRes as Response);
+
+            expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST);
+            expect(mockRes.json).toHaveBeenCalledWith({ error: "ID inválido" });
+        });
+
+        it("should return 404 if variation not found", async () => {
+            const req = { params: { id: "1" } } as any;
+            mockRepo.findById.mockResolvedValue(null);
+
+            await controller.show(req, mockRes as Response);
+
+            expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.NOT_FOUND);
+            expect(mockRes.json).toHaveBeenCalledWith({ error: "Variation not found" });
+        });
+
+        it("should return 500 on error", async () => {
+            const req = { params: { id: "1" } } as any;
+            mockRepo.findById.mockRejectedValue(new Error("DB error"));
+
+            await controller.show(req, mockRes as Response);
+
+            expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.INTERNAL_SERVER_ERROR);
+            expect(mockRes.json).toHaveBeenCalledWith({ error: "Failed to fetch variation" });
+        });
+    });
+
+    describe("update", () => {
+        it("should update a variation successfully", async () => {
+            const req = { params: { id: "1" }, body: { name: "Updated" } } as any;
+            const variation = { id: 1, ...req.body };
+            mockRepo.update.mockResolvedValue(variation);
+
+            await controller.update(req, mockRes as Response);
+
+            expect(mockRepo.update).toHaveBeenCalledWith(1, req.body);
+            expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.OK);
+            expect(mockRes.json).toHaveBeenCalledWith(variation);
+        });
+
+        it("should return 400 if ID is invalid", async () => {
+            const req = { params: { id: "abc" }, body: {} } as any;
+
+            await controller.update(req, mockRes as Response);
+
+            expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST);
+            expect(mockRes.json).toHaveBeenCalledWith({ error: "ID inválido" });
+        });
+
+        it("should return 500 if repo throws", async () => {
+            const req = { params: { id: "1" }, body: {} } as any;
+            mockRepo.update.mockRejectedValue(new Error("DB error"));
+
+            await controller.update(req, mockRes as Response);
+
+            expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.INTERNAL_SERVER_ERROR);
+            expect(mockRes.json).toHaveBeenCalledWith({ error: "Failed to update variation" });
+        });
+    });
+
+    describe("destroy", () => {
+        it("should delete a variation successfully", async () => {
+            const req = { params: { id: "1" } } as any;
+            const variation = { id: 1, name: "Basic", price: 50, duration: 30, serviceId: 1 };
+            mockRepo.delete.mockResolvedValue(variation);
+
+            await controller.destroy(req, mockRes as Response);
+
+            expect(mockRepo.delete).toHaveBeenCalledWith(1);
+            expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.NO_CONTENT);
+            expect(mockRes.send).toHaveBeenCalled();
+        });
+
+        it("should return 400 if ID is invalid", async () => {
+            const req = { params: { id: "abc" } } as any;
+
+            await controller.destroy(req, mockRes as Response);
+
+            expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST);
+            expect(mockRes.json).toHaveBeenCalledWith({ error: "ID inválido" });
+        });
+
+        it("should return 404 if variation not found", async () => {
+            const req = { params: { id: "1" } } as any;
+            mockRepo.delete.mockResolvedValue(null as any);
+
+            await controller.destroy(req, mockRes as Response);
+
+            expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.NOT_FOUND);
+            expect(mockRes.json).toHaveBeenCalledWith({ error: "Variation not found" });
+        });
+
+        it("should return 500 if repo throws", async () => {
+            const req = { params: { id: "1" } } as any;
+            mockRepo.delete.mockRejectedValue(new Error("DB error"));
+
+            await controller.destroy(req, mockRes as Response);
+
+            expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.INTERNAL_SERVER_ERROR);
+            expect(mockRes.json).toHaveBeenCalledWith({ error: "Failed to delete variation" });
+        });
+    });
+});


### PR DESCRIPTION
…and tests

- Implemented `VariationController` with CRUD endpoints:
  - create: handles new variation creation
  - show: fetches variation by ID with validation
  - update: updates variation data
  - destroy: deletes variation by ID

- Created `IVariationRepository` interface extending `IBaseRepository`
  - Defines contract for persistence methods (create, findById, update, delete, count)

- Added Zod schemas for request validation:
  - `createVariationSchema` with fields: name, price, duration, serviceId
  - `updateVariationSchema` with optional fields for partial updates

- Implemented Jest tests for `VariationController`
  - Covered success and failure cases for create, show, update, destroy
  - Validates error handling (invalid ID, not found, repository errors)

This commit establishes a complete domain layer for variations, with controller, validation, repository abstraction and unit tests.